### PR TITLE
Full support for air-gapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,23 +191,25 @@ gitops_resources = {
 
 - `revision` (`Required`): revision number for manually triggering a bootstrap re-run; the bootstrap job also runs automatically when any input content changes (secrets, runtime info, gitops resources); bump revision to force a re-run without changing content; when all inputs are unchanged, `terraform plan` shows zero diff
 - `gitops_resources` (`Required`): resources applied with create-if-missing semantics, meant to be reconciled by Flux after bootstrap
-  - `.flux_instance_path` (`Required`): path to the `FluxInstance` manifest file; may contain `${variable}` references that are substituted using `runtime_info` values
-  - `.prerequisites_paths` (`Default: []`): ordered list of paths to prerequisite manifest files
+  - `gitops_resources.flux_instance_path` (`Required`): path to the `FluxInstance` manifest file; may contain `${variable}` references that are substituted using `runtime_info` values
+  - `gitops_resources.prerequisites_paths` (`Default: []`): ordered list of paths to prerequisite manifest files
 - `managed_resources` (`Default: {}`): resources reconciled by the bootstrap job on every run
-  - `.secrets_yaml` (`Default: ""`): multi-document Secret manifest YAML reconciled into the target namespace with server-side apply; all documents must be `Secret` objects and their namespace must be omitted or equal the `FluxInstance` namespace
-  - `.runtime_info` (`Optional`): when set, creates a `ConfigMap` named `flux-runtime-info` in the target namespace; its `.data` values are substituted into the `FluxInstance` manifest via `flux envsubst`; tracked in inventory and garbage-collected when removed
-    - `.data` (`Required`): key-value pairs for the ConfigMap data
-    - `.labels` (`Default: {}`): labels to set on the ConfigMap
-    - `.annotations` (`Default: {}`): annotations to set on the ConfigMap
+  - `managed_resources.secrets_yaml` (`Default: ""`): multi-document Secret manifest YAML reconciled into the target namespace with server-side apply; all documents must be `Secret` objects and their namespace must be omitted or equal the `FluxInstance` namespace
+  - `managed_resources.runtime_info` (`Optional`): when set, creates a `ConfigMap` named `flux-runtime-info` in the target namespace; its data values are substituted into the `FluxInstance` manifest via `flux envsubst`; tracked in inventory and garbage-collected when removed
+  - `managed_resources.runtime_info.data` (`Required`): key-value pairs for the ConfigMap data
+  - `managed_resources.runtime_info.labels` (`Default: {}`): labels to set on the ConfigMap
+  - `managed_resources.runtime_info.annotations` (`Default: {}`): annotations to set on the ConfigMap
 - `bootstrap_namespace` (`Default: "flux-operator-bootstrap"`): namespace for the bootstrap transport resources
-- `job_image` (`Default: {}`): bootstrap job container image
-  - `.repository` (`Default: "ghcr.io/controlplaneio-fluxcd/flux-operator-bootstrap"`): image repository; override for mirrored or air-gapped environments
-  - `.tag` (`Default: module version`): image tag; defaults to the module version
-  - `.pullPolicy` (`Default: "IfNotPresent"`): image pull policy
-- `operator_image` (`Default: {}`): Flux Operator container image; when set, overrides the defaults from the flux-operator Helm chart
-  - `.repository` (`Optional`): image repository
-  - `.tag` (`Optional`): image tag
-  - `.pullPolicy` (`Optional`): image pull policy
+- `job` (`Default: {}`): bootstrap job settings
+  - `job.image.repository` (`Default: "ghcr.io/controlplaneio-fluxcd/flux-operator-bootstrap"`): image repository; override for mirrored or air-gapped environments
+  - `job.image.tag` (`Default: module version`): image tag; defaults to the module version
+  - `job.image.pull_policy` (`Default: "IfNotPresent"`): image pull policy
+- `operator` (`Default: {}`): Flux Operator settings
+  - `operator.image.repository` (`Optional`): container image repository; when set, overrides the default from the flux-operator Helm chart
+  - `operator.image.tag` (`Optional`): container image tag
+  - `operator.image.pull_policy` (`Optional`): container image pull policy
+  - `operator.chart.repository` (`Default: "ghcr.io/controlplaneio-fluxcd/charts/flux-operator"`): OCI Helm chart repository (without the `oci://` prefix)
+  - `operator.chart.version` (`Optional`): Helm chart version constraint
 - `timeout` (`Default: "5m"`): timeout for `FluxInstance` readiness waiting and the bootstrap job
 
 **Note**: Secrets are not stored in the Terraform state. Managed resources

--- a/charts/flux-operator-bootstrap/templates/job.yaml
+++ b/charts/flux-operator-bootstrap/templates/job.yaml
@@ -15,8 +15,8 @@ spec:
       restartPolicy: Never
       containers:
       - name: bootstrap
-        image: "{{ .Values.jobImage.repository }}:{{ .Values.jobImage.tag }}"
-        imagePullPolicy: {{ .Values.jobImage.pullPolicy }}
+        image: "{{ .Values.job.image.repository }}:{{ .Values.job.image.tag }}"
+        imagePullPolicy: {{ .Values.job.image.pullPolicy }}
         env:
         - name: FLUX_INSTANCE_FILE
           value: /bootstrap/flux-instance.yaml
@@ -33,11 +33,15 @@ spec:
         - name: CONFIG_MAP_NAME
           value: {{ .Release.Name }}
         - name: OPERATOR_IMAGE_REPOSITORY
-          value: {{ .Values.operatorImage.repository | quote }}
+          value: {{ .Values.operator.image.repository | quote }}
         - name: OPERATOR_IMAGE_TAG
-          value: {{ .Values.operatorImage.tag | quote }}
+          value: {{ .Values.operator.image.tag | quote }}
         - name: OPERATOR_IMAGE_PULL_POLICY
-          value: {{ .Values.operatorImage.pullPolicy | quote }}
+          value: {{ .Values.operator.image.pullPolicy | quote }}
+        - name: OPERATOR_CHART_REPOSITORY
+          value: {{ .Values.operator.chart.repository | quote }}
+        - name: OPERATOR_CHART_VERSION
+          value: {{ .Values.operator.chart.version | quote }}
         - name: DEBUG_FAULT_INJECTION_MESSAGE
           value: {{ .Values.debugFaultInjectionMessage | quote }}
         - name: DEBUG_FLUX_OPERATOR_IMAGE_TAG

--- a/charts/flux-operator-bootstrap/values.yaml
+++ b/charts/flux-operator-bootstrap/values.yaml
@@ -1,12 +1,17 @@
-jobImage:
-  repository: ghcr.io/controlplaneio-fluxcd/flux-operator-bootstrap
-  tag: ""
-  pullPolicy: IfNotPresent
+job:
+  image:
+    repository: ghcr.io/controlplaneio-fluxcd/flux-operator-bootstrap
+    tag: ""
+    pullPolicy: IfNotPresent
 
-operatorImage:
-  repository: ""
-  tag: ""
-  pullPolicy: ""
+operator:
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: ""
+  chart:
+    repository: ghcr.io/controlplaneio-fluxcd/charts/flux-operator
+    version: ""
 
 gitopsResources:
   fluxInstance: ""

--- a/main.tf
+++ b/main.tf
@@ -50,13 +50,23 @@ resource "helm_release" "this" {
   max_history      = 5
 
   values = [yamlencode({
-    jobImage = merge(var.job_image, {
-      tag = coalesce(var.job_image.tag, local.module_version)
-    })
-    operatorImage = {
-      repository = var.operator_image.repository != null ? var.operator_image.repository : ""
-      tag        = var.operator_image.tag != null ? var.operator_image.tag : ""
-      pullPolicy = var.operator_image.pullPolicy != null ? var.operator_image.pullPolicy : ""
+    job = {
+      image = {
+        repository = var.job.image.repository
+        tag        = coalesce(var.job.image.tag, local.module_version)
+        pullPolicy = var.job.image.pull_policy
+      }
+    }
+    operator = {
+      image = {
+        repository = var.operator.image.repository != null ? var.operator.image.repository : ""
+        tag        = var.operator.image.tag != null ? var.operator.image.tag : ""
+        pullPolicy = var.operator.image.pull_policy != null ? var.operator.image.pull_policy : ""
+      }
+      chart = {
+        repository = var.operator.chart.repository
+        version    = var.operator.chart.version != null ? var.operator.chart.version : ""
+      }
     }
     gitopsResources = {
       fluxInstance  = local.flux_instance_yaml

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -18,6 +18,8 @@ inventory_config_map_name="inventory"
 operator_image_repository="${OPERATOR_IMAGE_REPOSITORY:-}"
 operator_image_tag="${OPERATOR_IMAGE_TAG:-}"
 operator_image_pull_policy="${OPERATOR_IMAGE_PULL_POLICY:-}"
+operator_chart_repository="${OPERATOR_CHART_REPOSITORY:-ghcr.io/controlplaneio-fluxcd/charts/flux-operator}"
+operator_chart_version="${OPERATOR_CHART_VERSION:-}"
 debug_fault_injection_message="${DEBUG_FAULT_INJECTION_MESSAGE:-}"
 debug_flux_operator_image_tag="${DEBUG_FLUX_OPERATOR_IMAGE_TAG:-}"
 field_manager="flux-operator-bootstrap"
@@ -577,10 +579,15 @@ install_flux_operator() {
     set_args="--set image.tag=${debug_flux_operator_image_tag} --set replicas=2"
     install_timeout="15s"
   fi
-  helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator \
+  version_args=""
+  if [ -n "${operator_chart_version}" ]; then
+    version_args="--version=${operator_chart_version}"
+  fi
+  helm install flux-operator "oci://${operator_chart_repository}" \
     --namespace="${namespace}" \
     --wait=watcher \
     --timeout="${install_timeout}" \
+    ${version_args} \
     ${set_args}
 }
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -296,8 +296,10 @@ module "bootstrap" {
   bootstrap_namespace = "${bootstrap_namespace}"
   revision            = ${revision}
 
-  job_image = {
-    tag = "${image_tag}"
+  job = {
+    image = {
+      tag = "${image_tag}"
+    }
   }
 
   debug_fault_injection_message  = "${fault_injection_message}"

--- a/variables.tf
+++ b/variables.tf
@@ -49,23 +49,31 @@ variable "bootstrap_namespace" {
   nullable    = false
 }
 
-variable "job_image" {
-  description = "Bootstrap job container image."
+variable "job" {
+  description = "Bootstrap job settings."
   type = object({
-    repository = optional(string, "ghcr.io/controlplaneio-fluxcd/flux-operator-bootstrap")
-    tag        = optional(string)
-    pullPolicy = optional(string, "IfNotPresent")
+    image = optional(object({
+      repository  = optional(string, "ghcr.io/controlplaneio-fluxcd/flux-operator-bootstrap")
+      tag         = optional(string)
+      pull_policy = optional(string, "IfNotPresent")
+    }), {})
   })
   default  = {}
   nullable = false
 }
 
-variable "operator_image" {
-  description = "Flux Operator container image. When set, overrides the defaults from the flux-operator Helm chart."
+variable "operator" {
+  description = "Flux Operator settings. 'image' overrides the container image defaults from the flux-operator Helm chart. 'chart' overrides the OCI Helm chart repository and version used to install the operator."
   type = object({
-    repository = optional(string)
-    tag        = optional(string)
-    pullPolicy = optional(string)
+    image = optional(object({
+      repository  = optional(string)
+      tag         = optional(string)
+      pull_policy = optional(string)
+    }), {})
+    chart = optional(object({
+      repository = optional(string, "ghcr.io/controlplaneio-fluxcd/charts/flux-operator")
+      version    = optional(string)
+    }), {})
   })
   default  = {}
   nullable = false


### PR DESCRIPTION
Introducing TF variables `operator.chart.repository` and `operator.chart.version` for `helm install flux-operator oci://...`. With this, all the OCI artifacts can be replaced to point to mirrors, fully supporting air-gapped environments.

This is a breaking change for the following TF variables:

- `job_image.repository` -> `job.image.repository`
- `job_image.tag` -> `job.image.tag`
- `job_image.pullPolicy` -> `job.image.pull_policy`
- `operator_image.repository` -> `operator.image.repository`
- `operator_image.tag` -> `operator.image.tag`
- `operator_image.pullPolicy` -> `operator.image.pull_policy`