### PR TITLE
Eliminate `job.image.tag` input, force module version for job container

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -29,9 +29,9 @@ jobs:
           echo "raw=${version}" >> "${GITHUB_OUTPUT}"
           echo "tag=v${version}" >> "${GITHUB_OUTPUT}"
 
-      - name: Update versions.tf
+      - name: Update Chart.yaml
         run: |
-          sed -i 's/module_version = "v[^"]*"/module_version = "${{ steps.version.outputs.tag }}"/' versions.tf
+          sed -i 's/^version: .*/version: ${{ steps.version.outputs.raw }}/' charts/flux-operator-bootstrap/Chart.yaml
 
       - name: Update README.md
         run: |
@@ -45,7 +45,7 @@ jobs:
           title: Prepare release ${{ steps.version.outputs.tag }}
           delete-branch: true
           body: |
-            Bumps `module_version` in `versions.tf` and version in `README.md` to `${{ steps.version.outputs.tag }}`.
+            Bumps `version` in `Chart.yaml` and in `README.md` to `${{ steps.version.outputs.tag }}`.
 
             **Don't forget to run the e2e for this branch before merging:**
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_REPOSITORY ?= terraform-kubernetes-flux-operator-bootstrap
+IMAGE_REPOSITORY ?= terraform-kubernetes-flux-operator-bootstrap-test
 IMAGE_TAG ?= dev
 IMAGE ?= $(IMAGE_REPOSITORY):$(IMAGE_TAG)
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ gitops_resources = {
 - `bootstrap_namespace` (`Default: "flux-operator-bootstrap"`): namespace for the bootstrap transport resources
 - `job` (`Default: {}`): bootstrap job settings
   - `job.image.repository` (`Default: "ghcr.io/controlplaneio-fluxcd/flux-operator-bootstrap"`): image repository; override for mirrored or air-gapped environments
-  - `job.image.tag` (`Default: module version`): image tag; defaults to the module version
   - `job.image.pull_policy` (`Default: "IfNotPresent"`): image pull policy
 - `operator` (`Default: {}`): Flux Operator settings
   - `operator.image.repository` (`Optional`): container image repository; when set, overrides the default from the flux-operator Helm chart

--- a/charts/flux-operator-bootstrap/templates/_helpers.tpl
+++ b/charts/flux-operator-bootstrap/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "flux-operator-bootstrap.test-image-repository" -}}
+terraform-kubernetes-flux-operator-bootstrap-test
+{{- end -}}
+
+{{- define "flux-operator-bootstrap.job-image-tag" -}}
+{{- if eq .Values.job.image.repository (include "flux-operator-bootstrap.test-image-repository" .) -}}
+dev
+{{- else -}}
+v{{ .Chart.Version }}
+{{- end -}}
+{{- end -}}

--- a/charts/flux-operator-bootstrap/templates/job.yaml
+++ b/charts/flux-operator-bootstrap/templates/job.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: bootstrap
-        image: "{{ .Values.job.image.repository }}:{{ .Values.job.image.tag }}"
+        image: "{{ .Values.job.image.repository }}:{{ include "flux-operator-bootstrap.job-image-tag" . }}"
         imagePullPolicy: {{ .Values.job.image.pullPolicy }}
         env:
         - name: FLUX_INSTANCE_FILE

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -2,7 +2,7 @@
 
 ## Releasing
 
-1. Run the [prepare-release](https://github.com/controlplaneio-fluxcd/terraform-kubernetes-flux-operator-bootstrap/actions/workflows/prepare-release.yaml) workflow from the GitHub Actions UI with the desired version (e.g. `0.1.0` or `v0.1.0`). This opens a PR that bumps `module_version` in `versions.tf` and the version in `README.md`.
+1. Run the [prepare-release](https://github.com/controlplaneio-fluxcd/terraform-kubernetes-flux-operator-bootstrap/actions/workflows/prepare-release.yaml) workflow from the GitHub Actions UI with the desired version (e.g. `0.1.0` or `v0.1.0`). This opens a PR that bumps `version` in `Chart.yaml` and in `README.md`.
 
 2. Run the [e2e](https://github.com/controlplaneio-fluxcd/terraform-kubernetes-flux-operator-bootstrap/actions/workflows/e2e.yaml) workflow against the PR branch to validate. The e2e workflow will not be triggered automatically in this PR because the PR is created by a workflow, so you need to trigger it manually from the GitHub Actions UI.
 

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,6 @@ resource "helm_release" "this" {
     job = {
       image = {
         repository = var.job.image.repository
-        tag        = coalesce(var.job.image.tag, local.module_version)
         pullPolicy = var.job.image.pull_policy
       }
     }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -5,10 +5,9 @@ export NO_COLOR=1
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cluster_name="flux-operator-bootstrap-e2e"
-image_repository="terraform-kubernetes-flux-operator-bootstrap"
+image_repository="terraform-kubernetes-flux-operator-bootstrap-test"
 image_tag="dev"
 image="${image_repository}:${image_tag}"
-module_image="ghcr.io/controlplaneio-fluxcd/flux-operator-bootstrap:${image_tag}"
 inventory_config_map_name="inventory"
 success_tf_dir="$(mktemp -d)"
 failure_tf_dir="$(mktemp -d)"
@@ -281,7 +280,7 @@ provider "kubernetes" {
 resource "terraform_data" "kind_load_image" {
   depends_on = [module.kind_cluster]
 
-  input = "${module_image}"
+  input = "${image}"
 
   provisioner "local-exec" {
     command = "kind load docker-image \${self.input} --name ${cluster_name}"
@@ -298,7 +297,7 @@ module "bootstrap" {
 
   job = {
     image = {
-      tag = "${image_tag}"
+      repository = "${image_repository}"
     }
   }
 
@@ -336,8 +335,6 @@ EOF
 section "Cluster Setup"
 note "Resetting kind cluster ${cluster_name}"
 kind delete cluster --name "${cluster_name}" 2>/dev/null || true
-note "Tagging local image ${image} as ${module_image} for module consumption"
-docker tag "${image}" "${module_image}"
 
 section "Happy Path"
 note "Rendering success scenario Terraform root"

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,6 @@ variable "job" {
   type = object({
     image = optional(object({
       repository  = optional(string, "ghcr.io/controlplaneio-fluxcd/flux-operator-bootstrap")
-      tag         = optional(string)
       pull_policy = optional(string, "IfNotPresent")
     }), {})
   })

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,3 @@
-locals {
-  module_version = "v0.0.2"
-}
-
 terraform {
   required_version = ">= 1.11.0"
 


### PR DESCRIPTION
Also making the chart version equal the module version.