### PR TITLE
Add support for flux-operator chart values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ IMAGE_REPOSITORY ?= terraform-kubernetes-flux-operator-bootstrap-test
 IMAGE_TAG ?= dev
 IMAGE ?= $(IMAGE_REPOSITORY):$(IMAGE_TAG)
 
+SHELL := /bin/bash -o pipefail
+
 .PHONY: docker-build
 docker-build:
 	docker build -t $(IMAGE) .

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ are reconciled on every bootstrap run. `managed_resources.secrets_yaml` is
 reconciled into the target namespace with server-side apply.
 `managed_resources.runtime_info` is applied as a `ConfigMap` named
 `flux-runtime-info` in the target namespace and its data values are substituted
-into the `FluxInstance` manifest before the initial apply. This enables
-Flux's `Kustomization.spec.postBuild` variable substitution for the
-`FluxInstance` itself by referencing the same `ConfigMap` via
-`spec.postBuild.substituteFrom`.
+into the `FluxInstance` manifest before the initial apply. For steady-state
+variable substitution, use `.spec.kustomize.patches` in the `FluxInstance` to
+patch the generated Flux `Kustomization` (from `.spec.sync`) with
+`spec.postBuild.substituteFrom` referencing the same `ConfigMap`.
 
 Callers must configure the HashiCorp Helm and Kubernetes providers for the
 module.
@@ -136,8 +136,9 @@ When `managed_resources.runtime_info` is set, the bootstrap job:
 
 This allows the `FluxInstance` manifest to use variable references like
 `${cluster_name}` that are resolved at bootstrap time. For steady-state
-reconciliation, configure the Flux sync `Kustomization` to reference the same
-`ConfigMap` via `spec.postBuild.substituteFrom`.
+reconciliation, use `.spec.kustomize.patches` in the `FluxInstance` to patch
+the generated Flux `Kustomization` (from `.spec.sync`) with
+`spec.postBuild.substituteFrom` referencing the same `ConfigMap`.
 
 ### Same-module cluster creation
 
@@ -171,20 +172,89 @@ module "flux_operator_bootstrap" {
 }
 ```
 
+### Root module subdirectory
+
 If your Terraform root module lives below the Git repo root, anchor manifest
 paths with `path.root`, for example:
 
 ```text
 repo/
 ├── clusters/staging/flux-system/flux-instance.yaml
-└── terraform/
+└── .aws/terraform/
     └── main.tf  # path.root
 ```
 
 ```hcl
 gitops_resources = {
-  flux_instance_path = "${path.root}/../clusters/staging/flux-system/flux-instance.yaml"
+  flux_instance_path = "${path.root}/../../clusters/staging/flux-system/flux-instance.yaml"
 }
+```
+
+### Node scheduling
+
+If the cluster uses dedicated nodes with taints (e.g. provisioned by Karpenter
+`NodePool`s), the node pool manifests can be deployed as prerequisites via
+`gitops_resources.prerequisites_paths` so the target nodes are available before
+the bootstrap job runs.
+
+Affinity and tolerations can then be configured at each layer:
+
+**Bootstrap job** — uses `job.affinity` and `job.tolerations`:
+
+```hcl
+module "flux_operator_bootstrap" {
+  # ...
+
+  job = {
+    tolerations = [{
+      key      = "node-role.kubernetes.io/control-plane"
+      operator = "Exists"
+      effect   = "NoSchedule"
+    }]
+  }
+}
+```
+
+**Flux Operator** — uses `operator.values` to pass Helm chart values:
+
+```hcl
+module "flux_operator_bootstrap" {
+  # ...
+
+  operator = {
+    values = {
+      tolerations = [{
+        key      = "node-role.kubernetes.io/control-plane"
+        operator = "Exists"
+        effect   = "NoSchedule"
+      }]
+    }
+  }
+}
+```
+
+**Flux components** (source-controller, etc.) — use `.spec.kustomize.patches`
+in the `FluxInstance` manifest to patch the generated Deployments:
+
+```yaml
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  # ...
+  kustomize:
+    patches:
+      - target:
+          kind: Deployment
+        patch: |
+          - op: add
+            path: /spec/template/spec/tolerations
+            value:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+                effect: NoSchedule
 ```
 
 ## Inputs
@@ -206,11 +276,9 @@ gitops_resources = {
   - `job.affinity` (`Default: linux node affinity`): pod affinity rules for the bootstrap job; defaults to scheduling on Linux nodes only (`kubernetes.io/os=linux`)
   - `job.tolerations` (`Default: []`): pod tolerations for the bootstrap job
 - `operator` (`Default: {}`): Flux Operator settings
-  - `operator.image.repository` (`Optional`): container image repository; when set, overrides the default from the flux-operator Helm chart
-  - `operator.image.tag` (`Optional`): container image tag
-  - `operator.image.pull_policy` (`Optional`): container image pull policy
-  - `operator.chart.repository` (`Default: "ghcr.io/controlplaneio-fluxcd/charts/flux-operator"`): OCI Helm chart repository (without the `oci://` prefix)
-  - `operator.chart.version` (`Optional`): Helm chart version constraint
+  - `operator.repository` (`Default: "ghcr.io/controlplaneio-fluxcd/charts/flux-operator"`): OCI Helm chart repository (without the `oci://` prefix)
+  - `operator.version` (`Optional`): Helm chart version constraint
+  - `operator.values` (`Default: {}`): Helm chart values object passed to the operator install; use this to customize the operator deployment (e.g. image overrides, node affinity, tolerations, resource limits)
 - `timeout` (`Default: "5m"`): timeout for `FluxInstance` readiness waiting and the bootstrap job
 
 **Note**: Secrets are not stored in the Terraform state. Managed resources

--- a/charts/flux-operator-bootstrap/templates/configmap.yaml
+++ b/charts/flux-operator-bootstrap/templates/configmap.yaml
@@ -12,6 +12,10 @@ data:
   {{ $key }}: |
 {{ $value | indent 4 }}
 {{- end }}
+{{- if .Values.operator.values }}
+  operator-values.yaml: |
+{{ .Values.operator.values | indent 4 }}
+{{- end }}
 {{- if .Values.managedResources.runtimeInfo.data }}
   runtime-info.env: |
 {{- range $key, $value := .Values.managedResources.runtimeInfo.data }}

--- a/charts/flux-operator-bootstrap/templates/job.yaml
+++ b/charts/flux-operator-bootstrap/templates/job.yaml
@@ -40,16 +40,14 @@ spec:
           value: {{ .Release.Namespace }}
         - name: CONFIG_MAP_NAME
           value: {{ .Release.Name }}
-        - name: OPERATOR_IMAGE_REPOSITORY
-          value: {{ .Values.operator.image.repository | quote }}
-        - name: OPERATOR_IMAGE_TAG
-          value: {{ .Values.operator.image.tag | quote }}
-        - name: OPERATOR_IMAGE_PULL_POLICY
-          value: {{ .Values.operator.image.pullPolicy | quote }}
         - name: OPERATOR_CHART_REPOSITORY
-          value: {{ .Values.operator.chart.repository | quote }}
+          value: {{ .Values.operator.repository | quote }}
         - name: OPERATOR_CHART_VERSION
-          value: {{ .Values.operator.chart.version | quote }}
+          value: {{ .Values.operator.version | quote }}
+{{- if .Values.operator.values }}
+        - name: OPERATOR_VALUES_FILE
+          value: /bootstrap/operator-values.yaml
+{{- end }}
         - name: DEBUG_FAULT_INJECTION_MESSAGE
           value: {{ .Values.debugFaultInjectionMessage | quote }}
         - name: DEBUG_FLUX_OPERATOR_IMAGE_TAG

--- a/charts/flux-operator-bootstrap/values.yaml
+++ b/charts/flux-operator-bootstrap/values.yaml
@@ -7,13 +7,9 @@ job:
   tolerations: []
 
 operator:
-  image:
-    repository: ""
-    tag: ""
-    pullPolicy: ""
-  chart:
-    repository: ghcr.io/controlplaneio-fluxcd/charts/flux-operator
-    version: ""
+  repository: ghcr.io/controlplaneio-fluxcd/charts/flux-operator
+  version: ""
+  values: ""
 
 gitopsResources:
   fluxInstance: ""

--- a/main.tf
+++ b/main.tf
@@ -59,15 +59,9 @@ resource "helm_release" "this" {
       tolerations = var.job.tolerations
     }
     operator = {
-      image = {
-        repository = var.operator.image.repository != null ? var.operator.image.repository : ""
-        tag        = var.operator.image.tag != null ? var.operator.image.tag : ""
-        pullPolicy = var.operator.image.pull_policy != null ? var.operator.image.pull_policy : ""
-      }
-      chart = {
-        repository = var.operator.chart.repository
-        version    = var.operator.chart.version != null ? var.operator.chart.version : ""
-      }
+      repository = var.operator.repository
+      version    = var.operator.version != null ? var.operator.version : ""
+      values     = length(var.operator.values) > 0 ? yamlencode(var.operator.values) : ""
     }
     gitopsResources = {
       fluxInstance  = local.flux_instance_yaml

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,11 +15,9 @@ runtime_info_labels_file="${RUNTIME_INFO_LABELS_FILE:-}"
 runtime_info_annotations_file="${RUNTIME_INFO_ANNOTATIONS_FILE:-}"
 runtime_info_config_map_name="${RUNTIME_INFO_CONFIG_MAP_NAME:-flux-runtime-info}"
 inventory_config_map_name="inventory"
-operator_image_repository="${OPERATOR_IMAGE_REPOSITORY:-}"
-operator_image_tag="${OPERATOR_IMAGE_TAG:-}"
-operator_image_pull_policy="${OPERATOR_IMAGE_PULL_POLICY:-}"
 operator_chart_repository="${OPERATOR_CHART_REPOSITORY:-ghcr.io/controlplaneio-fluxcd/charts/flux-operator}"
 operator_chart_version="${OPERATOR_CHART_VERSION:-}"
+operator_values_file="${OPERATOR_VALUES_FILE:-}"
 debug_fault_injection_message="${DEBUG_FAULT_INJECTION_MESSAGE:-}"
 debug_flux_operator_image_tag="${DEBUG_FLUX_OPERATOR_IMAGE_TAG:-}"
 field_manager="flux-operator-bootstrap"
@@ -480,16 +478,11 @@ helm_release_status() {
 }
 
 install_flux_operator() {
+  values_args=""
   set_args=""
   install_timeout="${timeout}"
-  if [ -n "${operator_image_repository}" ]; then
-    set_args="${set_args} --set image.repository=${operator_image_repository}"
-  fi
-  if [ -n "${operator_image_tag}" ]; then
-    set_args="${set_args} --set image.tag=${operator_image_tag}"
-  fi
-  if [ -n "${operator_image_pull_policy}" ]; then
-    set_args="${set_args} --set image.imagePullPolicy=${operator_image_pull_policy}"
+  if [ -n "${operator_values_file}" ]; then
+    values_args="-f ${operator_values_file}"
   fi
   if [ -n "${debug_flux_operator_image_tag}" ]; then
     set_args="--set image.tag=${debug_flux_operator_image_tag} --set replicas=2"
@@ -504,6 +497,7 @@ install_flux_operator() {
     --wait=watcher \
     --timeout="${install_timeout}" \
     ${version_args} \
+    ${values_args} \
     ${set_args}
 }
 

--- a/scripts/e2e-batch-1.sh
+++ b/scripts/e2e-batch-1.sh
@@ -235,6 +235,36 @@ if [ "${custom_toleration_effect}" != "NoSchedule" ]; then
   exit 1
 fi
 
+section "Operator Chart Values"
+note "Uninstalling flux-operator to test fresh install with custom values"
+helm --kube-context "kind-${cluster_name}" delete flux-operator -n flux-system --no-hooks || true
+note "Re-rendering with custom operator chart values"
+operator_values='{
+    tolerations = [{
+      key      = "node-role.kubernetes.io/control-plane"
+      operator = "Exists"
+      effect   = "NoSchedule"
+    }]
+  }'
+render_root_module "${success_tf_dir}" "flux-operator-bootstrap" "" "rotated" "" 5 "" "5m" "${operator_values}"
+terraform -chdir="${success_tf_dir}" apply -no-color -auto-approve
+assert_flux_runtime_ready
+note "Verifying flux-operator deployment has custom tolerations from operator.values"
+op_toleration_key="$(kubectl --context "kind-${cluster_name}" -n flux-system get deployment flux-operator \
+  -o jsonpath='{.spec.template.spec.tolerations[0].key}')"
+if [ "${op_toleration_key}" != "node-role.kubernetes.io/control-plane" ]; then
+  echo "flux-operator deployment did not have the expected toleration from operator.values" >&2
+  echo "Expected key: node-role.kubernetes.io/control-plane, Got: ${op_toleration_key}" >&2
+  exit 1
+fi
+op_toleration_effect="$(kubectl --context "kind-${cluster_name}" -n flux-system get deployment flux-operator \
+  -o jsonpath='{.spec.template.spec.tolerations[0].effect}')"
+if [ "${op_toleration_effect}" != "NoSchedule" ]; then
+  echo "flux-operator deployment did not have the expected toleration effect from operator.values" >&2
+  echo "Expected: NoSchedule, Got: ${op_toleration_effect}" >&2
+  exit 1
+fi
+
 section "Destroy Behavior"
 note "Verifying Flux resources exist before destroy"
 kubectl_get_flux_operator_resources
@@ -244,5 +274,5 @@ note "Destroying happy-path bootstrap root (includes kind cluster)"
 terraform -chdir="${success_tf_dir}" destroy -no-color -auto-approve
 
 section "Assertions"
-note "Verified prerequisites, managed secret reconciliation, secret rotation, RBAC cleanup, Flux readiness, idempotent rerun, job scheduling (affinity/tolerations), and clean destroy"
+note "Verified prerequisites, managed secret reconciliation, secret rotation, RBAC cleanup, Flux readiness, idempotent rerun, job scheduling (affinity/tolerations), operator chart values, and clean destroy"
 print_elapsed_total

--- a/scripts/e2e-helpers.sh
+++ b/scripts/e2e-helpers.sh
@@ -166,6 +166,7 @@ render_root_module() {
   revision="${6:-1}"
   job_scheduling="${7:-}"
   timeout="${8:-5m}"
+  operator_values="${9:-}"
   fixtures_dir="${tf_dir}-fixtures"
   fixture_root_name="$(basename "${fixtures_dir}")"
   prerequisites_dir="${fixtures_dir}/tenants"
@@ -330,6 +331,14 @@ cat <<'JOBEOF'
 JOBEOF
 fi)
   }
+
+$(if [ -n "${operator_values}" ]; then
+cat <<OPEOF
+  operator = {
+    values = ${operator_values}
+  }
+OPEOF
+fi)
 
   timeout = "${timeout}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -76,17 +76,11 @@ variable "job" {
 }
 
 variable "operator" {
-  description = "Flux Operator settings. 'image' overrides the container image defaults from the flux-operator Helm chart. 'chart' overrides the OCI Helm chart repository and version used to install the operator."
+  description = "Flux Operator settings. 'repository' and 'version' control the OCI Helm chart used to install the operator. 'values' is an optional object of Helm chart values passed to the operator install."
   type = object({
-    image = optional(object({
-      repository  = optional(string)
-      tag         = optional(string)
-      pull_policy = optional(string)
-    }), {})
-    chart = optional(object({
-      repository = optional(string, "ghcr.io/controlplaneio-fluxcd/charts/flux-operator")
-      version    = optional(string)
-    }), {})
+    repository = optional(string, "ghcr.io/controlplaneio-fluxcd/charts/flux-operator")
+    version    = optional(string)
+    values     = optional(any, {})
   })
   default  = {}
   nullable = false


### PR DESCRIPTION
Closes: #7

Introducing `operator.values` for passing Helm values to the `helm install flux-operator oci://...` command.

This eliminates `operator.image` (which is part of the operator values API), and moves `operator.chart.repository` to `operator.repository` and `operator.chart.version` to `operator.version`.