### PR TITLE
Replace `null_resource` with `terraform_data`

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,11 +510,11 @@ module "flux_operator_bootstrap" {
   - `job.tolerations` (`Default: []`): pod tolerations for the bootstrap job
   - `job.host_network` (`Default: false`): run the bootstrap job with host networking; required when the job must install a CNI plugin (e.g. Cilium) since pod networking is unavailable until the CNI is running
 - `timeout` (`Default: "10m"`): timeout for `FluxInstance` readiness waiting and the bootstrap job
-- `debug_on_failure` (`Default: false`): when true, creates a `null_resource` that polls the bootstrap `Job` and relays its logs to Terraform output when the `Job` fails or never reaches a terminal state. The `null_resource` runs in parallel with `helm_release` and only triggers when `helm_release` will install or upgrade (i.e. on inputs change or `revision` bump). Requirements on the Terraform execution environment:
+- `debug_on_failure` (`Default: false`): when true, creates a `terraform_data` resource that polls the bootstrap `Job` and relays its logs to Terraform output when the `Job` fails or never reaches a terminal state. The `terraform_data` resource runs in parallel with `helm_release` and only triggers when `helm_release` will install or upgrade (i.e. on inputs change or `revision` bump). Requirements on the Terraform execution environment:
   - `bash` must be on `PATH` — the `local-exec` provisioner calls `["bash", "-c", …]`. On Linux and macOS this is native `bash`; on Windows, `bash.exe` from [Git for Windows](https://gitforwindows.org/) (Git Bash) satisfies this
   - `kubectl` must be on `PATH`
   - `kubectl` must be configured with credentials for the target cluster (via `KUBECONFIG`, the default `~/.kube/config`, or any mechanism resolvable by `kubectl` in the same environment Terraform runs in)
-  - The `hashicorp/null` provider (~> 3.2) is a required provider of this module
+  - The `hashicorp/null` provider (~> 3.2) is a required provider of this module (retained for state cleanup of the legacy `null_resource.debug_on_failure`; will be removed in a follow-up release)
 
 **Note**: Secrets are not stored in the Terraform state. Managed resources
 are reconciled with server-side apply and drift from manual `kubectl` changes

--- a/main.tf
+++ b/main.tf
@@ -98,19 +98,19 @@ resource "helm_release" "this" {
   values = [local.helm_values_yaml]
 }
 
-# null_resource.debug_on_failure polls the bootstrap Job and relays its
+# terraform_data.debug_on_failure polls the bootstrap Job and relays its
 # stdout/stderr to Terraform output when the Job fails. It depends on the
 # namespace and (optionally) the secret but NOT on helm_release, so that it
 # still runs when helm_release fails. Re-runs exactly when the Helm values
 # hash changes (which matches when helm_release itself will install/upgrade).
 # Both poll loops use the shared `timeout` input so there are no custom
 # timeouts to tune.
-resource "null_resource" "debug_on_failure" {
+resource "terraform_data" "debug_on_failure" {
   count = var.debug_on_failure ? 1 : 0
 
   depends_on = [kubernetes_namespace_v1.this, kubernetes_secret_v1.this]
 
-  triggers = {
+  triggers_replace = {
     values_hash = local.helm_values_hash
   }
 

--- a/scripts/debug-relay.sh
+++ b/scripts/debug-relay.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# debug-relay.sh is executed by Terraform's null_resource.debug_on_failure via
+# debug-relay.sh is executed by Terraform's terraform_data.debug_on_failure via
 # `bash -c "$(file debug-relay.sh)"`. It polls the bootstrap Job and relays its
 # logs back to the Terraform apply output whenever the Job failed or never
 # reached a terminal state. The caller supplies these environment variables:

--- a/scripts/e2e-batch-2.sh
+++ b/scripts/e2e-batch-2.sh
@@ -41,7 +41,7 @@ fi
 
 note "Verifying debug logs were relayed to Terraform output"
 if ! grep -q "flux-operator-bootstrap job logs" "${failure_apply_log}"; then
-  echo "Debug null_resource did not relay job logs to Terraform output" >&2
+  echo "Debug terraform_data did not relay job logs to Terraform output" >&2
   exit 1
 fi
 if ! grep -q "DEBUG OUTPUT" "${failure_apply_log}"; then

--- a/scripts/e2e-debug-shell.sh
+++ b/scripts/e2e-debug-shell.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Shell smoke test for the debug_on_failure null_resource. Validates that the
+# Shell smoke test for the debug_on_failure terraform_data resource. Validates that the
 # bash interpreter on the host (POSIX bash on Linux/macOS, Git Bash on Windows)
 # can run the local-exec template that the module ships
 # (scripts/debug-relay.sh.tpl) end to end. It does not need Docker, kind, or a

--- a/test/debug-shell/main.tf
+++ b/test/debug-shell/main.tf
@@ -1,12 +1,5 @@
 terraform {
   required_version = ">= 1.11.0"
-
-  required_providers {
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 3.2"
-    }
-  }
 }
 
 # This root exercises the exact same local-exec script that the module ships
@@ -26,8 +19,8 @@ variable "timeout_seconds" {
   default = 30
 }
 
-resource "null_resource" "debug_on_failure" {
-  triggers = {
+resource "terraform_data" "debug_on_failure" {
+  triggers_replace = {
     # Re-run on every apply so successive smoke-test runs always exercise the
     # provisioner. The real module uses a content hash here.
     timestamp = timestamp()

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "timeout" {
 }
 
 variable "debug_on_failure" {
-  description = "When true, creates a null_resource that polls the bootstrap Job and relays its logs via kubectl on failure so the failure cause surfaces in Terraform output. Requires kubectl to be available and configured (via KUBECONFIG or default kubeconfig) in the Terraform execution environment, with credentials for the target cluster. The relay only runs when the helm_release is being installed or upgraded — i.e. on inputs change or revision bump — and only prints when the bootstrap Job fails or never reaches a terminal state."
+  description = "When true, creates a terraform_data resource that polls the bootstrap Job and relays its logs via kubectl on failure so the failure cause surfaces in Terraform output. Requires kubectl to be available and configured (via KUBECONFIG or default kubeconfig) in the Terraform execution environment, with credentials for the target cluster. The relay only runs when the helm_release is being installed or upgraded — i.e. on inputs change or revision bump — and only prints when the bootstrap Job fails or never reaches a terminal state."
   type        = bool
   default     = false
   nullable    = false

--- a/versions.tf
+++ b/versions.tf
@@ -10,6 +10,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 3.0"
     }
+    # Retained for state-cleanup of the legacy null_resource.debug_on_failure
+    # (now terraform_data.debug_on_failure). Will be removed in a follow-up
+    # release once consumers have applied the migration.
     null = {
       source  = "hashicorp/null"
       version = "~> 3.2"


### PR DESCRIPTION
Part of: #39

This will need 2 releases, one for removing `null_resource`, and then one for removing the `hashicorp/null` provider afterwards. Removing both on the same release is a breaking change.