### PR TITLE
Add support for environment variables on the bootstrap Job

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ other `data` source that returns a secret value.
   - `job.affinity` (`Default: linux node affinity`): pod affinity rules for the bootstrap job; defaults to scheduling on Linux nodes only (`kubernetes.io/os=linux`)
   - `job.tolerations` (`Default: []`): pod tolerations for the bootstrap job
   - `job.host_network` (`Default: false`): run the bootstrap job with host networking; required when the job must install a CNI plugin (e.g. Cilium) since pod networking is unavailable until the CNI is running
+  - `job.env` (`Default: {}`): additional environment variables to pass to the bootstrap job container, for example to configure proxy settings.
 - `timeout` (`Default: "10m"`): timeout for `FluxInstance` readiness waiting and the bootstrap job
 - `debug_on_failure` (`Default: false`): when true, creates a `terraform_data` resource that polls the bootstrap `Job` and relays its logs to Terraform output when the `Job` fails or never reaches a terminal state. The `terraform_data` resource runs in parallel with `helm_release` and only triggers when `helm_release` will install or upgrade (i.e. on inputs change or `revision` bump). Requirements on the Terraform execution environment:
   - `bash` must be on `PATH` — the `local-exec` provisioner calls `["bash", "-c", …]`. On Linux and macOS this is native `bash`; on Windows, `bash.exe` from [Git for Windows](https://gitforwindows.org/) (Git Bash) satisfies this

--- a/charts/flux-operator-bootstrap/templates/job.yaml
+++ b/charts/flux-operator-bootstrap/templates/job.yaml
@@ -74,6 +74,12 @@ spec:
         - name: RUNTIME_INFO_CONFIG_MAP_NAME
           value: flux-runtime-info
 {{- end }}
+{{- if .Values.job.env }}
+{{- range $key, $value := .Values.job.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+{{- end }}
+{{- end }}
         volumeMounts:
         - name: bootstrap-manifest
           mountPath: /bootstrap

--- a/charts/flux-operator-bootstrap/values.yaml
+++ b/charts/flux-operator-bootstrap/values.yaml
@@ -6,6 +6,7 @@ job:
   affinity: {}
   tolerations: []
   hostNetwork: false
+  env: {}
 
 gitopsResources:
   instance: ""

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ locals {
       affinity    = var.job.affinity
       tolerations = var.job.tolerations
       hostNetwork = var.job.host_network
+      env         = var.job.env
     }
     gitopsResources = {
       instance = local.flux_instance_yaml

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,7 @@ variable "job" {
     })
     tolerations  = optional(list(any), [])
     host_network = optional(bool, false)
+    env          = optional(map(string), {})
   })
   default  = {}
   nullable = false


### PR DESCRIPTION
## Summary
Adds support for configuring environment variables on the bootstrap Job container.

This allows users to pass proxy-related variables such as `HTTP_PROXY`, `HTTPS_PROXY` directly to the bootstrap Job, which is required in enterprise proxied networks where direct outbound access to OCI/Helm chart registries is blocked. It also enables passing arbitrary environment variables to the bootstrap Job for other use cases.

Closes #57.

## Why this is needed
`managed_resources.runtime_info.data` can be used for runtime data and manifest substitution, but it does not configure the environment of the bootstrap Job itself.

The bootstrap Job needs network access while it is running, before Flux Operator is installed. In proxied environments, the Job must receive proxy environment variables directly in order to reach external registries such as:

```
ghcr.io/controlplaneio-fluxcd/charts/flux-operator
```

## Changes
- Adds support for configuring environment variables on the bootstrap Job.
- Extends the module input schema to accept Job environment variables.
- Renders the configured environment variables into the bootstrap Job container.
- Keeps the setting optional, preserving the existing default behavior.

## Example
```
module "flux_operator_bootstrap" {
  source  = "controlplaneio-fluxcd/flux-operator-bootstrap/kubernetes"
  version = "0.5.0"

  revision = var.bootstrap_revision

  job = {
    env = {
      HTTP_PROXY  = "..."
      HTTPS_PROXY = "..."
      NO_PROXY    = "..."
      SOMEOTHERKEY = SOMEOTHERVALUE
    }
  }
}
```

## Testing
Tested successfully in an enterprise proxied Kubernetes environment where direct access to ghcr.io is blocked.
With the proxy variables configured on the bootstrap Job, the Job was able to reach the Flux Operator chart repository and complete the bootstrap successfully.

## Backward compatibility
This change is backward compatible.
If no environment variables are configured, the bootstrap Job behavior remains unchanged.