### PR TITLE
Provider version constraints now use >=

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,10 @@ permissions:
 
 jobs:
   e2e-pending:
+    # Fork PRs don't have write access to the statuses API, so skip the
+    # commit-status updates entirely. The e2e aggregate job still enforces
+    # pass/fail via its Verify result step.
+    if: github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     steps:
       - name: Set pending status on PR
@@ -130,6 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update status on PR
+        if: github.event.pull_request.head.repo.fork != true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/versions.tf
+++ b/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
Per TF's version constraints [best practices](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#best-practices), reusable TF modules should use `>=` provider version constraints and let root modules manage upper version bounds.

Resolves #60.